### PR TITLE
Fix for Decorating existing method

### DIFF
--- a/AssemblyToProcess/AssemblyToProcess.csproj
+++ b/AssemblyToProcess/AssemblyToProcess.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
     <DisableFody>true</DisableFody>
     <Optimize>true</Optimize>
   </PropertyGroup>

--- a/AssemblyToProcess/ClassWithBaseAccess.cs
+++ b/AssemblyToProcess/ClassWithBaseAccess.cs
@@ -1,0 +1,13 @@
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+public class ClassWithBaseAccess
+{
+    public int ReplacedCount => StaticWithBaseAccess.ReplacedCount;
+    public IEnumerable<int> Yield => StaticWithBaseAccess.YieldMethod();
+
+    public Task<int> AsyncWithLambdaReplacement => StaticWithBaseAccess.LambdaReplacementMethod();
+    
+    public Task<int> AsyncDecorator => StaticWithBaseAccess.AsyncMethod();
+}

--- a/AssemblyToProcess/StaticWithBaseAccess.cs
+++ b/AssemblyToProcess/StaticWithBaseAccess.cs
@@ -1,0 +1,25 @@
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+public static class StaticWithBaseAccess
+{
+    public static int ReplacedCount => 0;
+    
+    public static IEnumerable<int> YieldMethod()
+    {
+        for (var i = 0; i < 10; i++)
+            yield return i;
+    }
+
+    public static Task<int> LambdaReplacementMethod()
+    {
+        return Task.FromResult(0);
+    }
+
+    public static async Task<int> AsyncMethod()
+    {
+        await Task.Delay(1);
+        return 0;
+    }
+}

--- a/AssemblyToProcess/StaticWithBaseAccessReplacement.cs
+++ b/AssemblyToProcess/StaticWithBaseAccessReplacement.cs
@@ -1,0 +1,76 @@
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Ionad;
+
+[StaticReplacement(typeof(StaticWithBaseAccess))]
+public static class StaticWithBaseAccessReplacement
+{
+    
+    
+    
+    public static int ReplacedCount
+    {
+        get 
+        {
+            using(ThrowOnRecursion.Check())
+            {
+                return StaticWithBaseAccess.ReplacedCount + 1;
+            } 
+        }
+    }
+
+
+    public static IEnumerable<int> YieldMethod()
+    {
+        using(ThrowOnRecursion.Check())
+        {
+            foreach (var i in StaticWithBaseAccess.YieldMethod())
+            {
+                yield return i + 10;
+            }
+        }
+    }
+
+    public static Task<int> LambdaReplacementMethod()
+    {
+        using(ThrowOnRecursion.Check())
+        {
+            return Task.Run(async () => await StaticWithBaseAccess.LambdaReplacementMethod() + 1);
+        }
+    }
+
+    public static async Task<int> AsyncMethod()
+    {
+        await Task.Delay(1);
+        return await StaticWithBaseAccess.AsyncMethod() + 1;
+    }
+}
+
+public static class ThrowOnRecursion
+{
+    private static AsyncLocal<int> CallCount = new AsyncLocal<int>();
+    public static IDisposable Check()
+    {
+        if (CallCount.Value == 0)
+        {
+            CallCount.Value++;
+            return new ExitRecursion();
+            
+        }
+        else
+        {
+            throw new InvalidOperationException("Recursion detected");
+        }
+    }
+
+    private class ExitRecursion : IDisposable
+    {
+        public void Dispose()
+        {
+            ThrowOnRecursion.CallCount.Value--;
+        }
+    }
+}

--- a/Tests/BaseMethodAccessTests.cs
+++ b/Tests/BaseMethodAccessTests.cs
@@ -1,0 +1,34 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+public partial class ModuleWeaverTests
+{
+    [Fact]
+    public void EnsureHasCanAccessBaseMethodsWithoutStackOverflow()
+    {
+        var instance = testResult.GetInstance("ClassWithBaseAccess");
+        Assert.Equal(1, instance.ReplacedCount);
+    }
+    
+    [Fact]
+    public void EnsureHasCanAccessBaseMethodsWithinAYield()
+    {
+        var instance = testResult.GetInstance("ClassWithBaseAccess");
+        Assert.Equal(Enumerable.Range(10, 10), instance.Yield);
+    }
+    
+    [Fact]
+    public async Task EnsureHasCanAccessBaseMethodViaLambda()
+    {
+        var instance = testResult.GetInstance("ClassWithBaseAccess");
+        Assert.Equal(1, await instance.AsyncWithLambdaReplacement);
+    }
+    
+    [Fact]
+    public async Task EnsureHasCanAccessBaseMethodWorksWithAsyncDecoration()
+    {
+        var instance = testResult.GetInstance("ClassWithBaseAccess");
+        Assert.Equal(1, await instance.AsyncDecorator);
+    }
+}

--- a/readme.md
+++ b/readme.md
@@ -50,6 +50,35 @@ public void SomeMethod()
 }
 ```
 
+You can also reference methods within the original static class to add defaults to optional parameters. For example:
+
+```csharp
+[StaticReplacement(typeof(System.Reactive.Linq.Observable))]
+public static class QueryableSubstitute
+{
+
+    public static IObservable<IList<TSource>> Delay<TSource>(this IObservable<TSource> source, TimeSpan timeSpan)
+    {
+        return System.Reactive.Linq.Delay<TSource>(source, timeSpan, RxApp.TaskpoolScheduler);
+    }
+}
+
+public async Task<int> SomeMethod()
+{
+    return await Observable.Return(1).Delay(TimeSpan.FromSeconds(1)).ToTask();
+}
+```
+
+
+### What gets compiled 
+
+```csharp
+public async Task<int> SomeMethod()
+{
+    return await Observable.Return(1).Delay(TimeSpan.FromSeconds(1), RxApp.TaskpoolScheduler).ToTask();
+}
+```
+
 
 ## Contributors
 


### PR DESCRIPTION
Added support for Decorator style replacement.

```
public static class StaticWithBaseAccess
{
    public static int ReplacedCount => 0;
}

[StaticReplacement(typeof(StaticWithBaseAccess))]
public static class StaticWithBaseAccessReplacement
{
    public static int ReplacedCount =>StaticWithBaseAccess.ReplacedCount + 1;
}
```

Bugs. 
Does not support async await.
Perhaps does not support Lambdas.

Working to support other types of generator pattern types.